### PR TITLE
Fix vast ai miner errors and push docker image

### DIFF
--- a/VAST_AI_MINER_SETUP.md
+++ b/VAST_AI_MINER_SETUP.md
@@ -1,0 +1,69 @@
+## Vanity Miner: Fix Summary, Redis Config, and Vast.ai Setup
+
+### What we fixed
+- **ENTRYPOINT and startup**: Added `entrypoint.sh` to auto-launch one worker per GPU and tail logs. Switched Dockerfiles to a **JSON-form ENTRYPOINT** to avoid signal handling issues and the Vast.ai warning.
+- **Redis/BullMQ reliability**: Updated `create2crunch/worker.js` to support `REDIS_URL` or discrete vars, optional `REDIS_USERNAME`/`REDIS_PASS`, and `REDIS_TLS=true`. Added resilient ioredis options (`maxRetriesPerRequest: null`, `enableReadyCheck: false`, retry strategy, and `reconnectOnError`) to prevent BullMQ lock/update issues.
+- **CUDA base + build path**: `create2crunch/Dockerfile.working` targets CUDA 11.8 on Ubuntu 20.04 and wires the new entrypoint.
+
+### Files changed
+- `create2crunch/worker.js`: Redis URL/TLS/username support and resilient options.
+- `create2crunch/entrypoint.sh`: multi-GPU launcher + log tailing.
+- `create2crunch/Dockerfile.working`: copies `entrypoint.sh`, uses JSON-form ENTRYPOINT.
+- `create2crunch/Dockerfile`: aligned to use the same entrypoint pattern.
+
+### Which Dockerfile to use
+- **Build with**: `create2crunch/Dockerfile.working` (CUDA 11.8, Ubuntu 20.04).
+
+### Build and push commands
+```bash
+# Build
+docker build -f create2crunch/Dockerfile.working -t liqliq/vanity-miner:latest ./create2crunch
+
+# Login (when prompted, paste your Docker Hub Personal Access Token)
+docker login -u liqliq
+# paste token when prompted
+
+# Push
+docker push liqliq/vanity-miner:latest
+```
+
+### How the container starts now
+- The image’s ENTRYPOINT runs the multi-GPU launcher automatically. No custom start command is required.
+- If you need to run it manually inside the container:
+```bash
+bash /home/entrypoint.sh
+```
+
+### Vast.ai setup
+- **Image**: `docker.io/liqliq/vanity-miner:latest`
+- **GPU**: enable GPU for the instance.
+- **Start command**: leave empty (ENTRYPOINT handles startup).
+- **Environment variables** (choose one of the two options below):
+  - Using a single URL:
+    - `REDIS_URL` (e.g., `rediss://user:pass@host:port` or `redis://host:port`).
+  - Using discrete vars:
+    - `REDIS_HOST`: your Redis hostname
+    - `REDIS_PORT`: your Redis port
+    - `REDIS_USERNAME`: set if your Redis requires it (e.g., `default`)
+    - `REDIS_PASS`: your Redis password
+    - `REDIS_TLS`: `true` if Redis requires TLS (e.g., Redis Cloud)
+- Optional:
+  - `MINER_PATH` (defaults to `/home/target/release/fourfourfourfour`)
+  - No need to set `DEVICE_ID`; one worker per detected GPU is launched automatically.
+
+### Local run example (for quick verification)
+```bash
+docker run --rm --gpus all \
+  -e REDIS_HOST=YOUR_HOST \
+  -e REDIS_PORT=YOUR_PORT \
+  -e REDIS_USERNAME=default \
+  -e REDIS_PASS=YOUR_PASSWORD \
+  -e REDIS_TLS=true \
+  liqliq/vanity-miner:latest
+```
+
+### Troubleshooting checklist
+- **Redis auth/TLS**: If using Redis Cloud, set `REDIS_TLS=true` and include username/password (`REDIS_USERNAME`, `REDIS_PASS`), or use a `REDIS_URL` with credentials.
+- **GPU detection**: Ensure the instance exposes GPUs; inside the container `nvidia-smi --list-gpus` should list devices.
+- **Miner binary path**: Default `MINER_PATH=/home/target/release/fourfourfourfour` is built during image build. Override only if you customized.
+- **Logs**: The entrypoint tails `/tmp/miner_*.log` for each worker.

--- a/create2crunch/Dockerfile
+++ b/create2crunch/Dockerfile
@@ -25,7 +25,7 @@ COPY . .
 RUN cargo build --release
 
 # Install Node.js dependencies
-RUN npm install
+RUN npm install --only=production
 
 # Set environment variables with defaults
 ENV DEVICE_ID=0
@@ -33,5 +33,9 @@ ENV MINER_PATH=/home/target/release/fourfourfourfour
 ENV REDIS_HOST=localhost
 ENV REDIS_PORT=6379
 
-# Default command runs the Node.js worker
-CMD ["npm", "start"]
+# Copy entrypoint and make executable
+COPY entrypoint.sh /home/entrypoint.sh
+RUN chmod +x /home/entrypoint.sh
+
+# Use JSON-form ENTRYPOINT to prevent signal handling issues
+ENTRYPOINT ["bash", "/home/entrypoint.sh"]

--- a/create2crunch/Dockerfile.working
+++ b/create2crunch/Dockerfile.working
@@ -42,5 +42,9 @@ ENV MINER_PATH=/home/target/release/fourfourfourfour
 ENV REDIS_HOST=localhost
 ENV REDIS_PORT=6379
 
-# Default command
-CMD ["node", "worker.js"]
+# Copy entrypoint and make executable
+COPY entrypoint.sh /home/entrypoint.sh
+RUN chmod +x /home/entrypoint.sh
+
+# Use JSON-form ENTRYPOINT to avoid signal handling issues
+ENTRYPOINT ["bash", "/home/entrypoint.sh"]

--- a/create2crunch/entrypoint.sh
+++ b/create2crunch/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "🚀 Starting Vanity Miner"
+
+if command -v nvidia-smi >/dev/null 2>&1; then
+  nvidia-smi --list-gpus || true
+  GPU_COUNT=$(nvidia-smi --list-gpus | wc -l || echo 0)
+else
+  echo "nvidia-smi not found; assuming 0 GPUs"
+  GPU_COUNT=0
+fi
+
+echo "Found ${GPU_COUNT} GPU(s)"
+
+# Ensure logs directory exists
+mkdir -p /tmp
+
+if [ "$GPU_COUNT" -gt 0 ]; then
+  for DEVICE_ID in $(seq 0 $((GPU_COUNT-1))); do
+    echo "Starting worker for GPU ${DEVICE_ID}"
+    DEVICE_ID=${DEVICE_ID} nohup node /home/worker.js > "/tmp/miner_${DEVICE_ID}.log" 2>&1 &
+  done
+else
+  echo "No GPUs detected; starting a single CPU worker as fallback"
+  DEVICE_ID=0 nohup node /home/worker.js > "/tmp/miner_0.log" 2>&1 &
+fi
+
+# Tail logs from all workers
+sleep 1
+if ls /tmp/miner_*.log >/dev/null 2>&1; then
+  echo "Workers started. Tailing logs..."
+  exec tail -F /tmp/miner_*.log
+else
+  echo "No logs found to tail; exiting"
+  exit 1
+fi

--- a/create2crunch/worker.js
+++ b/create2crunch/worker.js
@@ -3,11 +3,40 @@ const { spawn } = require('child_process');
 const path = require('path');
 
 // Redis connection configuration
-const redisConfig = {
-    host: process.env.REDIS_HOST || 'localhost',
-    port: process.env.REDIS_PORT || 6379,
-    password: process.env.REDIS_PASS || '',
-};
+// Prefer REDIS_URL if provided; otherwise construct from discrete env vars
+const useRedisUrl = process.env.REDIS_URL && process.env.REDIS_URL.trim().length > 0;
+const redisTlsEnabledEnv = (process.env.REDIS_TLS || '').toLowerCase();
+const redisTlsEnabled = redisTlsEnabledEnv === '1' || redisTlsEnabledEnv === 'true' || redisTlsEnabledEnv === 'yes';
+
+const redisConfig = useRedisUrl
+  ? {
+      url: process.env.REDIS_URL,
+      // Robust defaults for BullMQ/ioredis in containerized environments
+      maxRetriesPerRequest: null,
+      enableReadyCheck: false,
+      lazyConnect: false,
+      retryStrategy: (times) => Math.min(times * 50, 2000),
+      reconnectOnError: (err) => {
+        const targetErrors = ['READONLY', 'ETIMEDOUT', 'ECONNRESET'];
+        return targetErrors.some((code) => err.message && err.message.includes(code));
+      },
+    }
+  : {
+      host: process.env.REDIS_HOST || 'localhost',
+      port: Number(process.env.REDIS_PORT || 6379),
+      password: process.env.REDIS_PASS || undefined,
+      username: process.env.REDIS_USERNAME || undefined,
+      tls: redisTlsEnabled ? {} : undefined,
+      // Robust defaults for BullMQ/ioredis in containerized environments
+      maxRetriesPerRequest: null,
+      enableReadyCheck: false,
+      lazyConnect: false,
+      retryStrategy: (times) => Math.min(times * 50, 2000),
+      reconnectOnError: (err) => {
+        const targetErrors = ['READONLY', 'ETIMEDOUT', 'ECONNRESET'];
+        return targetErrors.some((code) => err.message && err.message.includes(code));
+      },
+    };
 
 // Worker configuration
 const DEVICE_ID = process.env.DEVICE_ID || '0';
@@ -15,112 +44,125 @@ const MINER_PATH = process.env.MINER_PATH || '/home/target/release/fourfourfourf
 const MINING_TIMEOUT = 295000; // 4 minutes 55 seconds (5 seconds buffer before queue timeout)
 
 console.log(`Starting vanity salt worker for device ${DEVICE_ID}`);
-console.log(`Redis config: ${redisConfig.host}:${redisConfig.port}`);
+if (redisConfig.url) {
+  console.log(`Redis config (url): ${redisConfig.url.replace(/:[^:@/]*@/, ':***@')}`);
+} else {
+  console.log(
+    `Redis config: ${redisConfig.host}:${redisConfig.port}` +
+      (redisConfig.username ? ` user=${redisConfig.username}` : '') +
+      (redisConfig.password ? ' pass=***' : '') +
+      (redisConfig.tls ? ' tls' : '')
+  );
+}
 console.log(`Miner path: ${MINER_PATH}`);
 
 // Create worker to process vanity salt mining jobs
-const worker = new Worker('vanitySalt', async (job) => {
+const worker = new Worker(
+  'vanitySalt',
+  async (job) => {
     const { deployerAddress, initCodeHash, tokenId } = job.data;
-    
+
     console.log(`Starting mining job ${job.id} for token ${tokenId}`);
     console.log(`Deployer: ${deployerAddress}`);
     console.log(`Init code hash: ${initCodeHash}`);
-    
+
     return new Promise((resolve, reject) => {
-        // Spawn the GPU miner process
-        const proc = spawn(MINER_PATH, [
-            deployerAddress,
-            '0x0000000000000000000000000000000000000000', // calling address (null address)
-            initCodeHash,
-            DEVICE_ID,
-            '' // empty endpoint URL since we handle results here
-        ]);
+      // Spawn the GPU miner process
+      const proc = spawn(MINER_PATH, [
+        deployerAddress,
+        '0x0000000000000000000000000000000000000000', // calling address (null address)
+        initCodeHash,
+        DEVICE_ID,
+        '' // empty endpoint URL since we handle results here
+      ]);
 
-        let found = null;
-        let minerOutput = '';
+      let found = null;
+      let minerOutput = '';
 
-        // Set up timeout
-        const timeout = setTimeout(() => {
-            console.log(`Mining job ${job.id} timed out after ${MINING_TIMEOUT}ms`);
-            proc.kill('SIGINT');
-            reject(new Error('Mining timeout'));
-        }, MINING_TIMEOUT);
+      // Set up timeout
+      const timeout = setTimeout(() => {
+        console.log(`Mining job ${job.id} timed out after ${MINING_TIMEOUT}ms`);
+        try { proc.kill('SIGINT'); } catch (e) {}
+        reject(new Error('Mining timeout'));
+      }, MINING_TIMEOUT);
 
-        // Capture stdout for result parsing
-        proc.stdout.on('data', (data) => {
-            const output = data.toString();
-            minerOutput += output;
-            
-            // Look for the expected output format: "SALT: 0x... ADDRESS: 0x..."
-            const match = output.match(/SALT: (0x[0-9a-fA-F]{64}) ADDRESS: (0x[0-9a-fA-F]{40})/);
-            if (match) {
-                found = {
-                    salt: match[1],
-                    vanityAddress: match[2]
-                };
-                console.log(`Found vanity address for job ${job.id}: ${found.vanityAddress}`);
-                proc.kill('SIGINT'); // Gracefully stop the miner
-            }
-        });
+      // Capture stdout for result parsing
+      proc.stdout.on('data', (data) => {
+        const output = data.toString();
+        minerOutput += output;
 
-        // Capture stderr for debugging
-        proc.stderr.on('data', (data) => {
-            console.error(`Miner stderr: ${data}`);
-        });
+        // Look for the expected output format: "SALT: 0x... ADDRESS: 0x..."
+        const match = output.match(/SALT: (0x[0-9a-fA-F]{64}) ADDRESS: (0x[0-9a-fA-F]{40})/);
+        if (match) {
+          found = {
+            salt: match[1],
+            vanityAddress: match[2],
+          };
+          console.log(`Found vanity address for job ${job.id}: ${found.vanityAddress}`);
+          try { proc.kill('SIGINT'); } catch (e) {}
+        }
+      });
 
-        // Handle process exit
-        proc.on('exit', (code, signal) => {
-            clearTimeout(timeout);
-            
-            console.log(`Miner process exited with code ${code}, signal ${signal}`);
-            
-            if (found) {
-                console.log(`Job ${job.id} completed successfully`);
-                resolve(found);
-            } else {
-                console.log(`Job ${job.id} failed - no valid result found`);
-                reject(new Error('No valid vanity address found'));
-            }
-        });
+      // Capture stderr for debugging
+      proc.stderr.on('data', (data) => {
+        console.error(`Miner stderr: ${data}`);
+      });
 
-        // Handle process errors
-        proc.on('error', (err) => {
-            clearTimeout(timeout);
-            console.error(`Miner process error: ${err}`);
-            reject(err);
-        });
+      // Handle process exit
+      proc.on('exit', (code, signal) => {
+        clearTimeout(timeout);
+
+        console.log(`Miner process exited with code ${code}, signal ${signal}`);
+
+        if (found) {
+          console.log(`Job ${job.id} completed successfully`);
+          resolve(found);
+        } else {
+          console.log(`Job ${job.id} failed - no valid result found`);
+          reject(new Error('No valid vanity address found'));
+        }
+      });
+
+      // Handle process errors
+      proc.on('error', (err) => {
+        clearTimeout(timeout);
+        console.error(`Miner process error: ${err}`);
+        reject(err);
+      });
     });
-}, {
+  },
+  {
     connection: redisConfig,
     concurrency: 1, // Process one job at a time per worker
     removeOnComplete: 10, // Keep last 10 completed jobs
     removeOnFail: 50, // Keep last 50 failed jobs
-});
+  }
+);
 
 // Handle worker events
 worker.on('completed', (job, result) => {
-    console.log(`Worker completed job ${job.id} with result:`, result);
+  console.log(`Worker completed job ${job.id} with result:`, result);
 });
 
 worker.on('failed', (job, err) => {
-    console.error(`Worker failed job ${job.id}:`, err.message);
+  console.error(`Worker failed job ${job.id}:`, err && err.message ? err.message : err);
 });
 
 worker.on('error', (err) => {
-    console.error('Worker error:', err);
+  console.error('Worker error:', err);
 });
 
 // Graceful shutdown
 process.on('SIGINT', async () => {
-    console.log('Shutting down worker...');
-    await worker.close();
-    process.exit(0);
+  console.log('Shutting down worker...');
+  try { await worker.close(); } catch (e) {}
+  process.exit(0);
 });
 
 process.on('SIGTERM', async () => {
-    console.log('Shutting down worker...');
-    await worker.close();
-    process.exit(0);
+  console.log('Shutting down worker...');
+  try { await worker.close(); } catch (e) {}
+  process.exit(0);
 });
 
 console.log(`Worker started and waiting for vanity salt mining jobs...`);


### PR DESCRIPTION
Refactor Docker ENTRYPOINT, enhance Redis connection robustness, and implement multi-GPU worker startup to fix Vast.ai errors and BullMQ lock issues.

The Vast.ai "Internal error" was linked to Docker's ENTRYPOINT not being in JSON form, which is now resolved by using a dedicated `entrypoint.sh` script. BullMQ/Redis lock errors were addressed by adding comprehensive Redis connection options, including `REDIS_URL` support, TLS, username/password, and resilient `ioredis` settings to handle network instability. The new `entrypoint.sh` also correctly launches one worker per GPU and tails logs as intended.

---
<a href="https://cursor.com/background-agent?bcId=bc-60786051-aa54-40ae-b298-f6be19a741a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-60786051-aa54-40ae-b298-f6be19a741a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

